### PR TITLE
🐛 Script was referencing incorrect old branch name

### DIFF
--- a/Script/SSWLoginScript.ps1
+++ b/Script/SSWLoginScript.ps1
@@ -60,7 +60,7 @@ if ($ShareExists -eq $true) {
     Set-Variable -Name 'ScriptTemplateSource' -Value 'file://fileserver.sydney.ssw.com.au/DataSSW/DataSSWEmployees'
 }
 else {
-    Set-Variable -Name 'ScriptTemplateSource' -Value 'https://github.com/SSWConsulting/SSWSysAdmins.LoginScript/raw/master/'
+    Set-Variable -Name 'ScriptTemplateSource' -Value 'https://github.com/SSWConsulting/SSWSysAdmins.LoginScript/raw/main/'
 }
 
 #Initializing the LogFile


### PR DESCRIPTION
Regression from default branch name change - script would pull from `master` instead of `main`